### PR TITLE
Adding Container Health Check

### DIFF
--- a/pattern/api-gateway-fargate-cloudformation/files/service.yml
+++ b/pattern/api-gateway-fargate-cloudformation/files/service.yml
@@ -67,6 +67,13 @@ Resources:
           PortMappings:
             - ContainerPort: !Ref ContainerPort
               HostPort: !Ref ContainerPort
+          HealthCheck:
+            Command:
+              - "CMD-SHELL"
+              - "curl -f http://localhost/ || exit 1"
+            Interval: 5
+            Retries: 2
+            Timeout: 3
           LogConfiguration:
             LogDriver: 'awslogs'
             Options:

--- a/pattern/api-gateway-fargate-cloudformation/index.md
+++ b/pattern/api-gateway-fargate-cloudformation/index.md
@@ -81,6 +81,7 @@ The following AWS CloudFormation template defines a basic NGINX task that runs i
 Important things to note:
 
 - The `AWS::ServiceDiscovery::Service` must use a [DNS record type of SRV](https://en.wikipedia.org/wiki/SRV_record). SRV records keep track of both the IP address as well as the port. This is required for API Gateway to be able to locate the task and send it traffic on the right port.
+- Container image must have the curl command installed in order to evaluate the Container Health Check commands.
 
 #### Define the API Gateway
 


### PR DESCRIPTION
In order to replace unhealthy tasks, Task Definition needs to have the Container Health Check configured for Service Discovery service.

# Description

As per [AWS Docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-discovery.html):

> We recommend you use container-level health checks managed by Amazon ECS for your service discovery service.
>  HealthCheckCustomConfig—Amazon ECS manages health checks on your behalf. Amazon ECS uses information from container and health checks, and your task state, to update the health with AWS Cloud Map. This is specified using the --health-check-custom-config parameter when creating your service discovery service. For more information, see [HealthCheckCustomConfig](https://docs.aws.amazon.com/cloud-map/latest/api/API_HealthCheckCustomConfig.html) in the AWS Cloud Map API Reference.


## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] [Understand the repository structure](./docs/structure.md)
* [X] [Add yourself as an author](./docs/add-yourself-as-an-author.md)
* [X] [Add your pattern](./docs/add-a-pattern.md)
* [X] [Add a great SVG diagram for your pattern](./docs/svg-diagram-process.md)
* [X] [Read our general contribution guidelines](./CONTRIBUTING.md)
* [X] [Read our code of conduct](../CODE_OF_CONDUCT.md)
* [X] Confirm your pattern frontmatter lints correctly. i.e. run `npm install && npm run lint` locally from your dev environment
