### PR TITLE
fix dates not parsing in Safari and Firefox

### DIFF
--- a/pattern/inject-config-files-ecs-task-definition/index.md
+++ b/pattern/inject-config-files-ecs-task-definition/index.md
@@ -10,7 +10,7 @@ filterDimensions:
     value: pattern
 authors:
   - peckn
-date: Dec 2022
+date: Dec 1, 2022
 ---
 
 The following snippet shows how to do runtime file generation and injection in an ECS task definition.

--- a/pattern/uninstall-ecs-anywhere/index.md
+++ b/pattern/uninstall-ecs-anywhere/index.md
@@ -11,7 +11,7 @@ filterDimensions:
     value: anywhere
 authors:
   - peckn
-date: Dec 2021
+date: Dec 1, 2021
 ---
 
 The following script removes the components of ECS Anywhere from a host.


### PR DESCRIPTION
# Description

This fixes a bug where there was a hydration mismatch in Firefox and Safari due to differences in Date parsing logic between Chromium based browsers, and Firefox + Safari.

The posts with unparsable dates ended up out of order in the markup in these browsers, causing mismatches in where you ended up when clicking on a pattern.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] [Understand the repository structure](./docs/structure.md)
* [ ] [Add yourself as an author](./docs/add-yourself-as-an-author.md)
* [ ] [Add your pattern](./docs/add-a-pattern.md)
* [ ] [Add a great SVG diagram for your pattern](./docs/svg-diagram-process.md)
* [ ] [Read our general contribution guidelines](./CONTRIBUTING.md)
* [ ] [Read our code of conduct](../CODE_OF_CONDUCT.md)
* [ ] Confirm your pattern frontmatter lints correctly. i.e. run `npm install && npm run lint` locally from your dev environment
