### PR TITLE
changes bottlerocket variant to ecs-2 and adds link to docs for udpater

### DIFF
--- a/pattern/ecs-ec2-bottlerocket-cluster/files/cluster.yml
+++ b/pattern/ecs-ec2-bottlerocket-cluster/files/cluster.yml
@@ -21,7 +21,7 @@ Parameters:
   ECSAMI:
     Description: The Bottlerocket Amazon Machine Image ID used for the cluster
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
-    Default: /aws/service/bottlerocket/aws-ecs-1/x86_64/latest/image_id
+    Default: /aws/service/bottlerocket/aws-ecs-2/x86_64/latest/image_id
   VpcId:
     Type: AWS::EC2::VPC::Id
     Description: VPC ID where the ECS cluster is launched

--- a/pattern/ecs-ec2-bottlerocket-cluster/index.md
+++ b/pattern/ecs-ec2-bottlerocket-cluster/index.md
@@ -40,7 +40,7 @@ We will use the following CloudFormation template to define a cluster that uses 
 
 A few specific things to note in this template are:
 
-The latest Bottlerocket Amazon Machine Image (AMI) id is retrieved from the SSM parameter `/aws/service/bottlerocket/aws-ecs-1/x86_64/latest/image_id`.
+The latest Bottlerocket Amazon Machine Image (AMI) id is retrieved from the SSM parameter `/aws/service/bottlerocket/aws-ecs-2/x86_64/latest/image_id`.
 
 Bottlerocket uses [TOML](https://toml.io/en/) configuration format. You can specify which cluster to connect to using the following userdata config:
 
@@ -59,7 +59,7 @@ The following template defines a service that uses the capacity provider to requ
 
 #### (Optional) Deploy the cluster auto updater
 
-Bottlerocket has it's own automatic updater process which can update the Bottlerocket operating system in waves across your cluster, with automatic task draining to avoid downtime during restarts. You can find the [full source code for the automatic updater on Github](https://github.com/bottlerocket-os/bottlerocket-ecs-updater). Or you can use the following embedded stack to setup the updater:
+Bottlerocket has it's own automatic updater process which can update the Bottlerocket operating system in waves across your cluster, with automatic task draining to avoid downtime during restarts. You can find the [full source code for the automatic updater on Github](https://github.com/bottlerocket-os/bottlerocket-ecs-updater) and [read the full ECS Updater documentation on Bottlerocket.dev](https://bottlerocket.dev/en/ecs-updater/). Or you can use the following embedded stack to setup the updater:
 
 <<< files/bottlerocket-updater.yml
 


### PR DESCRIPTION
# Description

- `ecs-2` variant is a more current variant type
- Adds link to ECS Updater docs

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] [Understand the repository structure](./docs/structure.md)
* [x] [Add yourself as an author](./docs/add-yourself-as-an-author.md)
* [x] [Add your pattern](./docs/add-a-pattern.md)
* [x] [Add a great SVG diagram for your pattern](./docs/svg-diagram-process.md)
* [x] [Read our general contribution guidelines](./CONTRIBUTING.md)
* [x] [Read our code of conduct](../CODE_OF_CONDUCT.md)
* [x] Confirm your pattern frontmatter lints correctly. i.e. run `npm install && npm run lint` locally from your dev environment
